### PR TITLE
BUG: adding support for parsing a string of unencoded list of items

### DIFF
--- a/src/healdata_utils/utils.py
+++ b/src/healdata_utils/utils.py
@@ -37,9 +37,11 @@ def parse_dictionary_str(string, item_sep, keyval_sep):
     """
     stritems = string.strip().split(item_sep)
     items = {}
-    for stritem in stritems:
+    for idx, stritem in enumerate(stritems):
         item = stritem.split(keyval_sep, 1)
-        items[item[0]] = item[1].strip()
+        key = f"UNENCODED_{idx}" if len(item) == 1 else item[0]
+        val = item[0] if len(item) == 1 else item[1]
+        items[key] = val.strip()
 
     return items
 


### PR DESCRIPTION
Found that https://github.com/norc-heal/healdata-utils/blob/241eb7f62fd6fe1aa4f5da718e65c792ef57823c/src/healdata_utils/utils.py#L32 assumes that the input string is of format: `key_1, val_1 | key_2, val_2`. Modifying the code to also support strings of format: `val_1 | val_2`, etc so that the output dictionary is: `{unencoded_0: val_1, unencoded_1:val_2}` and so forth.